### PR TITLE
Fix #118: fix IPv6 leaks by disabling IPv6 altogether

### DIFF
--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -18,8 +18,7 @@ from .utils import (
     get_servers, get_server_value, get_config_value,
     set_config_value, get_ip_info, get_country_name,
     get_fastest_server, check_update, get_default_nic,
-    get_transferred_data, create_openvpn_config,
-    is_ipv6_disabled, patch_passfile
+    get_transferred_data, create_openvpn_config, patch_passfile
 )
 # Constants
 from .constants import (
@@ -640,7 +639,7 @@ def manage_ipv6(mode):
     if mode == "disable":
         logger.debug("Disabling IPv6")
         subprocess.run(["sysctl", "net.ipv6.conf.all.disable_ipv6=1"],
-                        stdout=subprocess.PIPE)
+                       stdout=subprocess.PIPE)
         logger.debug("IPv6 disabled successfully")
 
     elif mode == "restore":

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -639,12 +639,14 @@ def manage_ipv6(mode):
 
     if mode == "disable":
         logger.debug("Disabling IPv6")
-        subprocess.run(["sysctl", "net.ipv6.conf.all.disable_ipv6=1"])
+        subprocess.run(["sysctl", "net.ipv6.conf.all.disable_ipv6=1"],
+                        stdout=subprocess.PIPE)
         logger.debug("IPv6 disabled successfully")
 
     elif mode == "restore":
         logger.debug("Restoring IPv6")
-        subprocess.run(["sysctl", "net.ipv6.conf.all.disable_ipv6=0"])
+        subprocess.run(["sysctl", "net.ipv6.conf.all.disable_ipv6=0"],
+                       stdout=subprocess.PIPE)
         logger.debug("IPv6 restored successfully")
 
     else:


### PR DESCRIPTION
I noticed that the current iptables-based solution doesn't address IPv6 leaks correctly on my Arch Linux system. After reading issue #118, I think it might be beneficial to just disable IPv6 altogether using `sysctl net.ipv6.conf.all.disable_ipv6=0` when connecting to ProtonVPN, as it'll provide a guaranteed way to prevent IPv6 leaks. When user disconnects from ProtonVPN, IPv6 will be re-enabled (`net.ipv6.conf.all.disable_ipv6=0`).

I know this approach will cause users to lose previously-assigned IPv6 addresses, but I don't think this is a major issue. This could be easily addressed by reconnecting to the network, and the network will reassign IPv6 addresses.