### PR TITLE
fix: add uid to fetch full list of free servers

### DIFF
--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -384,6 +384,7 @@ def set_username_password(write=False):
     """Set the ProtonVPN Username and Password."""
 
     print()
+    ovpn_uid = input("Enter your ProtonVPN uid: ")
     ovpn_username = input("Enter your ProtonVPN OpenVPN username: ")
 
     # Ask for the password and confirmation until both are the same
@@ -402,6 +403,7 @@ def set_username_password(write=False):
             break
 
     if write:
+        set_config_value("USER", "uid", ovpn_uid)
         set_config_value("USER", "username", ovpn_username)
 
         with open(PASSFILE, "w") as f:

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -28,9 +28,11 @@ def call_api(endpoint, json_format=True, handle_errors=True):
     api_domain = get_config_value("USER", "api_domain").rstrip("/")
     url = api_domain + endpoint
     distribution, version, _ = distro.linux_distribution()
+    uid = get_config_value("USER", "uid")
     headers = {
         "x-pm-appversion": "LinuxVPN_{0}".format(VERSION),
         "x-pm-apiversion": "3",
+        "x-pm-uid": uid,
         "Accept": "application/vnd.protonmail.v1+json",
         "User-Agent": "ProtonVPN/{} (Linux; {}/{})".format(VERSION, distribution, version),
     }

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -450,6 +450,7 @@ def check_init():
 
             default_conf = {
                 "USER": {
+                    "uid": "uid",
                     "username": "username",
                     "tier": "0",
                     "default_protocol": "udp",


### PR DESCRIPTION
Without the `x-pm-uid` header, the server list, especially the free ones, returned by the API is unbelievably reduced (10 compared to actual number of 68).

The main problem is getting this uid needs to view cookies in the protonvpn dashboard, find a cookie named `AUTH-{uid}` and copy the uid out of its name.